### PR TITLE
Python Version Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The `deploy` directory contains:
 - `docker-compose.yml` - The Docker compose file.
 - `.env` - The environment file where you set your AWS credentials, SQS/S3 names, and AWS region.
 - `https_nginx.conf` - Nginx configuration file used as an entrypoint load balancer.
-- `diagnostics.sh`- A script for testing connectivity between services and printing useful information.
+- `diagnostic.sh`- A script for testing connectivity between services and printing useful information.
 - `tls` - A directory for storing TLS certificates (see [Securing Connections with SSL/TLS](#securing-connections-with-ssltls)).
 - `.htpasswd` - A file for storing basic auth credentials (see above).
 
@@ -164,9 +164,9 @@ docker run --name granulate-gprofiler --restart=always -d --pid=host --userns=ho
 ```
 
 ### Diagnostics
-If a service is restarted or stops, run the diagnostics.sh script to check service connectivity:
+If a service is restarted or stops, run the diagnostic.sh script to check service connectivity:
 ```shell
-./diagnostics.sh
+./diagnostic.sh
 ```
 
 If all OK there, take a look at the logs of the service that is not working properly.

--- a/src/gprofiler/Dockerfile
+++ b/src/gprofiler/Dockerfile
@@ -14,7 +14,7 @@ RUN yarn --cwd /frontend/ install
 COPY gprofiler/frontend /frontend
 RUN yarn build
 
-FROM python:3.12-bullseye
+FROM python:3.12.3-bullseye
 
 WORKDIR /usr/src/app
 EXPOSE 80

--- a/src/gprofiler_logging/Dockerfile
+++ b/src/gprofiler_logging/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.12.3
 
 WORKDIR /app
 EXPOSE 80


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Updated Dockerfiles in src folder to restrict the python version to 3.12.3 since 3.12 is pulling the newly added 3.12.4 version which breaks functionality.

## Related Issue
<!--- If there's an issue related, please link it here -->
<!--- If suggesting a new feature or a medium/big change, please discuss it in an issue first. -->
<!--- For small changes, it's okay to open a PR immediately. -->
https://github.com/Granulate/gprofiler-performance-studio/issues/22

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What does it improve? -->
Pulling from the repo and running currently uses the wrong python version and causes the build to break. Change is needed to resume normal functionality.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your changes are tested by the CI, you can just write that.-->
Tested this setting up Gprofiler Performance Studio on c7i.4xl in AWS on U22.04

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] I have updated the relevant documentation.
- [ X] I have added tests for new logic.
